### PR TITLE
classify branches into local and remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,22 @@ branches.sync = function(cwd, options) {
 };
 
 function parseBranches(str) {
-  if (!str) return [];
+  var res = {
+    local: [],
+    remote: []
+  }
+  if (!str) return res;
   var lines = str.trim().split(os.EOL);
-  var res = [];
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i].trim().replace(/^\*\s*/, '');
-    res.push(line.split('/').pop());
+    if('remotes/origin/HEAD -> origin/master' === line) {
+      // ignore - remotes/origin/HEAD -> origin/master
+      // do nothing
+    } else if(line.indexOf('remotes/origin') === 0) {
+      res.remote.push(line.split('/').pop());
+    } else {
+      res.local.push(line);
+    }
   }
   return res;
 }


### PR DESCRIPTION
The original one will list duplicated branches, because of there are two versions - local and remote, 
even three versions - an extra from 'remotes/origin/HEAD -> origin/master'.

Please deal with this PR and publish it into npm as soon as possible, I'm waiting for using it, ^_^.
Thanks! 