### PR TITLE
Classify the branches

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,22 @@ branches.sync = function(cwd, options) {
 };
 
 function parseBranches(str) {
-  if (!str) return [];
+  var res = {
+    local: [],
+    remote: []
+  }
+  if (!str) return res;
   var lines = str.trim().split(os.EOL);
-  var res = [];
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i].trim().replace(/^\*\s*/, '');
-    res.push(line.split('/').pop());
+    if('remotes/origin/HEAD -> origin/master' === line) {
+      // ignore - remotes/origin/HEAD -> origin/master
+      // do nothing
+    } else if(line.indexOf('remotes/origin') === 0) {
+      res.remote.push(line.split('/').pop());
+    } else {
+      res.local.push(line);
+    }
   }
   return res;
 }

--- a/index.js
+++ b/index.js
@@ -3,23 +3,46 @@
 var os = require('os');
 var cp = require('child_process');
 var extend = require('extend-shallow');
+var Promise = require('bluebird');
 
-function branches(cwd, options, cb) {
+function branches(cwd, options) {
+  var opts = extend({}, options, {cwd: cwd});
+
+  return new Promise(function(resolve, reject) {
+    // step 1. update the tracking remote branch
+    cp.exec('git remote update --prune', opts, function(err, stdout, stderr) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(null);
+    });
+  }).then(function() {
+    return new Promise(function(resolve, reject) {
+      // step 2. get all branches
+      cp.exec('git branch -a', opts, function(err, stdout, stderr) {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(parseBranches(stdout.toString()));
+      });
+    });
+  });
+}
+
+branches.async = function(cwd, options, cb) {
   if (typeof options === 'function') {
     cb = options;
     options = undefined;
   }
-
-  var opts = extend({}, options, {cwd: cwd});
-
-  cp.exec('git branch -a', opts, function(err, stdout, stderr) {
-    if (err) {
-      cb(err, null, stderr);
-      return;
-    }
-
-    cb(null, parseBranches(stdout.toString()));
-  });
+  branches(cwd, options)
+    .then(function(res) {
+      cb(null, res);
+    })
+    .catch(function(err) {
+      cb(err, null);
+    });
 }
 
 branches.sync = function(cwd, options) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "bluebird": "^3.5.1",
     "extend-shallow": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The original one will list duplicated branches, because of there are two versions - local and remote,
even three versions - an extra from 'remotes/origin/HEAD -> origin/master'.

Now, the output will be just like this:
`
{
  local: ['master', 'dev', 'test'],
  remote: ['master', 'dev']
}
`